### PR TITLE
Feature/actualizar dependencias 32

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     implementation("io.micronaut:micronaut-runtime")
     implementation("javax.annotation:javax.annotation-api")
     implementation("io.micronaut:micronaut-http-client")
-    implementation("io.micronaut.flyway:micronaut-flyway")
+    implementation("io.micronaut.flyway:micronaut-flyway:${ micronautFlywayVersion }")
     implementation("io.micronaut.sql:micronaut-jdbc-hikari")
     implementation("io.micronaut.data:micronaut-data-jdbc:${ micronautDataVersion }")
     implementation("io.micronaut.views:micronaut-views-thymeleaf")

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     implementation("javax.annotation:javax.annotation-api")
     implementation("io.micronaut:micronaut-http-client")
     implementation("io.micronaut.flyway:micronaut-flyway:${ micronautFlywayVersion }")
-    implementation("io.micronaut.sql:micronaut-jdbc-hikari")
+    implementation("io.micronaut.sql:micronaut-jdbc-hikari:${ micronautJdbcHikari }")
     implementation("io.micronaut.data:micronaut-data-jdbc:${ micronautDataVersion }")
     implementation("io.micronaut.views:micronaut-views-thymeleaf")
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id "com.github.johnrengelman.shadow" version "6.1.0"
     id "io.micronaut.application" version '1.1.0'
     id "idea"
-    id "com.github.ben-manes.versions" version "0.35.0"
+    id "com.github.ben-manes.versions" version "0.36.0"
     id 'jacoco'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ micronaut {
 }
 
 dependencies {
-    annotationProcessor("io.micronaut.data:micronaut-data-processor")
+    annotationProcessor("io.micronaut.data:micronaut-data-processor:${ micronautDataVersion }")
     annotationProcessor("org.projectlombok:lombok:${ lombokVersion }")
     annotationProcessor "org.mapstruct:mapstruct-processor:${ mapstructVersion }"
     compileOnly("org.graalvm.nativeimage:svm")
@@ -40,7 +40,7 @@ dependencies {
     implementation("io.micronaut:micronaut-http-client")
     implementation("io.micronaut.flyway:micronaut-flyway")
     implementation("io.micronaut.sql:micronaut-jdbc-hikari")
-    implementation("io.micronaut.data:micronaut-data-jdbc")
+    implementation("io.micronaut.data:micronaut-data-jdbc:${ micronautDataVersion }")
     implementation("io.micronaut.views:micronaut-views-thymeleaf")
 
     runtimeOnly("ch.qos.logback:logback-classic")

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,9 @@ dependencies {
     testImplementation "io.micronaut.test:micronaut-test-spock:${ micronautTestSpock }", {
         version { strictly "${ micronautTestSpock }" }
     }
+    testImplementation "org.codehaus.groovy:groovy:${ groovyVersion }", {
+        version { strictly "${ groovyVersion }" }
+    }
 
     runtimeOnly("ch.qos.logback:logback-classic")
     runtimeOnly("org.postgresql:postgresql")

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,10 @@ dependencies {
     implementation("io.micronaut.data:micronaut-data-jdbc:${ micronautDataVersion }")
     implementation("io.micronaut.views:micronaut-views-thymeleaf")
 
+    testImplementation "io.micronaut.test:micronaut-test-spock:${ micronautTestSpock }", {
+        version { strictly "${ micronautTestSpock }" }
+    }
+
     runtimeOnly("ch.qos.logback:logback-classic")
     runtimeOnly("org.postgresql:postgresql")
 

--- a/build.gradle
+++ b/build.gradle
@@ -43,11 +43,14 @@ dependencies {
     implementation("io.micronaut.data:micronaut-data-jdbc:${ micronautDataVersion }")
     implementation("io.micronaut.views:micronaut-views-thymeleaf")
 
-    testImplementation "io.micronaut.test:micronaut-test-spock:${ micronautTestSpock }", {
-        version { strictly "${ micronautTestSpock }" }
-    }
     testImplementation "org.codehaus.groovy:groovy:${ groovyVersion }", {
         version { strictly "${ groovyVersion }" }
+    }
+    testImplementation "org.spockframework:spock-core:${ spockVersion }", {
+        version { strictly "${ spockVersion }" }
+    }
+    testImplementation "io.micronaut.test:micronaut-test-spock:${ micronautTestSpock }", {
+        version { strictly "${ micronautTestSpock }" }
     }
 
     runtimeOnly("ch.qos.logback:logback-classic")

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,7 @@ micronautVersion=2.1.3
 micronautDataVersion=2.2.0
 micronautFlywayVersion=3.0.0
 micronautJdbcHikari=3.2.0
+micronautTestSpock=2.2.1
 postgresContainerVersion=postgres:13.1-alpine
 postgresContainerPort=5433
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,7 @@ micronautDataVersion=2.2.0
 micronautFlywayVersion=3.0.0
 micronautJdbcHikari=3.2.0
 micronautTestSpock=2.2.1
+spockVersion=2.0-M4-groovy-3.0
 postgresContainerVersion=postgres:13.1-alpine
 postgresContainerPort=5433
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
+groovyVersion=3.0.6
 micronautVersion=2.1.3
 micronautDataVersion=2.2.0
 micronautFlywayVersion=3.0.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,6 @@
 micronautVersion=2.1.3
 micronautDataVersion=2.2.0
+micronautFlywayVersion=3.0.0
 postgresContainerVersion=postgres:13.1-alpine
 postgresContainerPort=5433
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,7 @@
 micronautVersion=2.1.3
 micronautDataVersion=2.2.0
 micronautFlywayVersion=3.0.0
+micronautJdbcHikari=3.2.0
 postgresContainerVersion=postgres:13.1-alpine
 postgresContainerPort=5433
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 micronautVersion=2.1.3
+micronautDataVersion=2.2.0
 postgresContainerVersion=postgres:13.1-alpine
 postgresContainerPort=5433
 


### PR DESCRIPTION
closes #32 

Se actualizaron casi todas las dependencias, excepto :

```
The following dependencies have later milestone versions:
 - jakarta.persistence:jakarta.persistence-api [2.2.2 -> 3.0.0]
     https://github.com/eclipse-ee4j/jpa-api
```

Porque introduce cambios en paquetes que `Micronaut Data` aun no soporta.
